### PR TITLE
Add config flags to exclude lines from comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.6]
+- Added options `ignore-comments-after` and `ignore-comment-lines-containing`.
+
 ## [0.4]
 - Added dark mode support.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ footer-content = "© 2023 Jane Doe. All rights reserved."
 repository-type = "github"
 repository-url = "https://github.com/janedoe/myawesomeproject"
 repository-branch = "main"
+
+# In each comment, ignore everything following '@exclude'.
+# Default value: false
+respect-exclude = true
+# In each comment, ignore every line containing 'buf:lint'.
+exclude_buf_lint = true
 ```
 
 #### Main page content

--- a/README.md
+++ b/README.md
@@ -79,11 +79,12 @@ repository-type = "github"
 repository-url = "https://github.com/janedoe/myawesomeproject"
 repository-branch = "main"
 
-# In each comment, ignore everything following '@exclude'.
-# Default value: false
-respect-exclude = true
-# In each comment, ignore every line containing 'buf:lint'.
-exclude_buf_lint = true
+# In each comment, ignore everything that comes after (until end of the comment) one of the keywords.
+# Default value: []
+ignore-comments-after = ["@exclude"]
+# In each comment, ignore all lines that contain at least one keyword from the following list.
+# Default value: []
+ignore-comment-lines-containing = ["buf:lint"]
 ```
 
 #### Main page content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sabledocs"
-version = "0.5"
+version = "0.6"
 authors = [
   { name="Mark Vincze", email="mrk.vincze@gmail.com" },
 ]

--- a/src/sabledocs/proto_descriptor_parser.py
+++ b/src/sabledocs/proto_descriptor_parser.py
@@ -64,10 +64,10 @@ class ParseContext:
             return ""
         else:
             comments = location.comments
-            if self.config.exclude_buf_lint:
-                comments = '\n'.join([c for c in comments.splitlines() if "buf:lint" not in c])
-            if self.config.respect_exclude:
-                comments = comments.split("@exclude")[0]
+            for ignore_after in self.config.ignore_comments_after:
+                comments = comments.split(ignore_after)[0]
+            for ignore_line in self.config.ignore_comment_lines_containing:
+                comments = '\n'.join([c for c in comments.splitlines() if ignore_line not in c])
             return comments
 
     def GetLineNumber(self, path=""):

--- a/src/sabledocs/proto_descriptor_parser.py
+++ b/src/sabledocs/proto_descriptor_parser.py
@@ -60,7 +60,15 @@ class ParseContext:
 
     def GetComments(self, path=""):
         location = self.locations.get(self.path if path == "" else path, None)
-        return "" if location is None else location.comments
+        if location is None:
+            return ""
+        else:
+            comments = location.comments
+            if self.config.exclude_buf_lint:
+                comments = '\n'.join([c for c in comments.splitlines() if "buf:lint" not in c])
+            if self.config.respect_exclude:
+                comments = comments.split("@exclude")[0]
+            return comments
 
     def GetLineNumber(self, path=""):
         location = self.locations.get(self.path if path == "" else path, None)

--- a/src/sabledocs/sable_config.py
+++ b/src/sabledocs/sable_config.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from os import path
 import tomllib
+from typing import List
 
 
 class RepositoryType(Enum):
@@ -21,8 +22,8 @@ class SableConfig:
         self.repository_url = ""
         self.repository_branch = ""
         self.repository_type = RepositoryType.NONE
-        self.respect_exclude = False
-        self.exclude_buf_lint = False
+        self.ignore_comments_after: List[str] = []
+        self.ignore_comment_lines_containing: List[str] = []
 
         if path.exists(config_file_path):
             print(f"Configuration found in {config_file_path}")
@@ -54,8 +55,8 @@ class SableConfig:
                         case 'bitbucket':
                             self.repository_type = RepositoryType.BITBUCKET
 
-                self.respect_exclude = config_values.get('respect-exclude', False)
+                self.ignore_comments_after = config_values.get('ignore-comments-after', [])
 
-                self.exclude_buf_lint = config_values.get('exclude-buf-lint', False)
+                self.ignore_comment_lines_containing = config_values.get('ignore-comment-lines-containing', [])
         else:
             print("sabledocs.toml file not found, using default configuration.")

--- a/src/sabledocs/sable_config.py
+++ b/src/sabledocs/sable_config.py
@@ -21,6 +21,8 @@ class SableConfig:
         self.repository_url = ""
         self.repository_branch = ""
         self.repository_type = RepositoryType.NONE
+        self.respect_exclude = False
+        self.exclude_buf_lint = False
 
         if path.exists(config_file_path):
             print(f"Configuration found in {config_file_path}")
@@ -51,5 +53,9 @@ class SableConfig:
                             self.repository_type = RepositoryType.GITHUB
                         case 'bitbucket':
                             self.repository_type = RepositoryType.BITBUCKET
+
+                self.respect_exclude = config_values.get('respect-exclude', False)
+
+                self.exclude_buf_lint = config_values.get('exclude-buf-lint', False)
         else:
             print("sabledocs.toml file not found, using default configuration.")


### PR DESCRIPTION
We use `@exclude` to mark the point from which on the documentation should not be public.

We use the buf linter and do not want to show the linting commands in the public doc.