### PR TITLE
Hide packages on index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unpublished
+- Packages can now be hidden. Added
+  - option `hide-packages` to the config and
+  - iterable `non_hidden_packages` to be used in the templates `package.html` and `index.html`
+
 ## [0.6]
 - Added options `ignore-comments-after` and `ignore-comment-lines-containing`.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ ignore-comments-after = ["@exclude"]
 # In each comment, ignore all lines that contain at least one keyword from the following list.
 # Default value: []
 ignore-comment-lines-containing = ["buf:lint"]
+
+# In the templates, one can now use non_hidden_packages instead of packages where the following are hidden:
+# Default value: []
+hide-packages = ["google.protobuf"]
 ```
 
 #### Main page content

--- a/src/sabledocs/__main__.py
+++ b/src/sabledocs/__main__.py
@@ -38,6 +38,7 @@ def cli():
                 sable_config=sable_config,
                 package=package,
                 packages=sable_context.packages,
+                non_hidden_packages=sable_context.non_hidden_packages,
                 all_messages=sable_context.all_messages,
                 all_enums=sable_context.all_enums).encode('utf-8')
 
@@ -57,6 +58,7 @@ def cli():
             sable_config = sable_config,
             main_page_content = main_page_content,
             packages = sable_context.packages,
+            non_hidden_packages=sable_context.non_hidden_packages,
             all_messages = sable_context.all_messages,
             all_enums = sable_context.all_enums).encode('utf-8')
 

--- a/src/sabledocs/proto_descriptor_parser.py
+++ b/src/sabledocs/proto_descriptor_parser.py
@@ -362,5 +362,6 @@ def parse_proto_descriptor(sable_config: SableConfig):
                 packages.values(),
                 key=lambda p: (p.name)),
             all_messages,
-            all_enums)
+            all_enums,
+            sable_config)
 

--- a/src/sabledocs/proto_model.py
+++ b/src/sabledocs/proto_model.py
@@ -1,4 +1,5 @@
 from pprint import pformat
+from sabledocs.sable_config import SableConfig
 
 
 class CodeItem:
@@ -105,8 +106,13 @@ class LocationInfo:
 
 
 class SableContext:
-    def __init__(self, packages: list[Package], all_messages: list[Message], all_enums: list[Enum]):
+    def __init__(self, packages: list[Package], all_messages: list[Message], all_enums: list[Enum], sable_config: SableConfig):
         self.packages = packages
         self.all_messages = all_messages
         self.all_enums = all_enums
+        self.sable_config = sable_config
+
+    @property
+    def non_hidden_packages(self):
+        return [p for p in self.packages if p.name not in self.sable_config.hide_packages]
 

--- a/src/sabledocs/sable_config.py
+++ b/src/sabledocs/sable_config.py
@@ -24,6 +24,7 @@ class SableConfig:
         self.repository_type = RepositoryType.NONE
         self.ignore_comments_after: List[str] = []
         self.ignore_comment_lines_containing: List[str] = []
+        self.hide_packages: List[str] = []
 
         if path.exists(config_file_path):
             print(f"Configuration found in {config_file_path}")
@@ -58,5 +59,7 @@ class SableConfig:
                 self.ignore_comments_after = config_values.get('ignore-comments-after', [])
 
                 self.ignore_comment_lines_containing = config_values.get('ignore-comment-lines-containing', [])
+
+                self.hide_packages = config_values.get('hide-packages', [])
         else:
             print("sabledocs.toml file not found, using default configuration.")


### PR DESCRIPTION
There is a new option `hide-packages` where one can give a list of packages that should not be shown. The `SableContext` has a new computed property `non_hidden_packages` which respects that. The old member `packages` still contains both.

In the templates `index.html` and `package.html`, `non_hidden_packages` can be used in addition to the old `packages`.

I updated the readme and the changelog (I plan some more features, that's why I did not specify a new version number yet, but I am also fine with publishing individual features in individual new versions)