### PR TITLE
Support optional fields in proto3 syntax

### DIFF
--- a/src/sabledocs/proto_descriptor_parser.py
+++ b/src/sabledocs/proto_descriptor_parser.py
@@ -118,7 +118,7 @@ def parse_field(field: FieldDescriptorProto, ctx: ParseContext):
     mf = MessageField()
     mf.name = field.name
     mf.number = field.number
-    mf.label = to_label_name(field.label)
+    mf.label = to_label_name(field.label, field.proto3_optional)
     mf.description = ctx.GetComments()
     mf.description_html = markdown.markdown(mf.description)
     mf.line_number = ctx.GetLineNumber()
@@ -318,12 +318,13 @@ def to_type_name(type: FieldDescriptorProto.Type):
         case _: "unknown"
 
 
-def to_label_name(type):
+def to_label_name(type, proto3_optional):
+    if proto3_optional:
+        return "optional"
     match type:
-        case FieldDescriptorProto.Label.LABEL_OPTIONAL: return "optional"
         case FieldDescriptorProto.Label.LABEL_REQUIRED: return "required"
         case FieldDescriptorProto.Label.LABEL_REPEATED: return "repeated"
-        case _: ""
+        case _: return ""
 
 
 def parse_proto_descriptor(sable_config: SableConfig):

--- a/src/sabledocs/templates/_default/message.html
+++ b/src/sabledocs/templates/_default/message.html
@@ -35,7 +35,7 @@
       </td>
       <td>
         <code title="{{ field.full_type }}">
-          {% if field.label != "" and field.label != "optional" %}
+          {% if field.label != "" %}
             {{ field.label }}
           {% endif %}
           {{ common.type_name(field) }}


### PR DESCRIPTION
I haven't tested that with a syntax2 file. Maybe we need a general switch in the Context whether we deal with syntax2 or syntax3. That might also be a good idea, because in syntax3 there are no default values and so we can drop that column from the tables.