### PR TITLE
changed template config handling

### DIFF
--- a/src/sabledocs/__main__.py
+++ b/src/sabledocs/__main__.py
@@ -30,7 +30,7 @@ def cli():
     # Execute the main processing of the Proto contracts.
     sable_context = parse_proto_descriptor(sable_config)
 
-    template_base_dir = os.path.join(os.path.dirname(__file__), "templates", "_default") if sable_config.template == "_default" else f"templates/{sable_config.template}"
+    template_base_dir = sable_config.template if sable_config.template else os.path.join(os.path.dirname(__file__), "templates", "_default")
 
     jinja_env = Environment(
         loader=FileSystemLoader(searchpath=template_base_dir),

--- a/src/sabledocs/sable_config.py
+++ b/src/sabledocs/sable_config.py
@@ -14,7 +14,7 @@ class SableConfig:
     def __init__(self, config_file_path):
         self.module_title = "Protobuf module documentation"
         self.input_descriptor_file = "descriptor.pb"
-        self.template = "_default"
+        self.template = ""
         self.footer_content = ""
         self.main_page_content_file = ""
         self.output_dir = "sabledocs_output"


### PR DESCRIPTION
I see that the `template` directive is not exhibited in the sample `sabledocs.toml`. I'm guessing that's because you haven't finalized how that would work.

I needed to use some different template files, and I ended up making this minor change.

The default template directory `_default/` now appears fewer times in the code, and if `template` is specified in the config file, it is no longer required to be a subdirectory of the current working directory (but it still could be).