### PR TITLE
Add template_path config field to be able to specify the template folder path directly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sabledocs"
-version = "0.7"
+version = "0.8"
 authors = [
   { name="Mark Vincze", email="mrk.vincze@gmail.com" },
 ]

--- a/src/sabledocs/__main__.py
+++ b/src/sabledocs/__main__.py
@@ -30,7 +30,7 @@ def cli():
     # Execute the main processing of the Proto contracts.
     sable_context = parse_proto_descriptor(sable_config)
 
-    template_base_dir = os.path.join(os.path.dirname(__file__), "templates", "_default") if sable_config.template == "_default" else f"templates/{sable_config.template}"
+    template_base_dir = sable_config.template if sable_config.template else os.path.join(os.path.dirname(__file__), "templates", "_default")
 
     jinja_env = Environment(
         loader=FileSystemLoader(searchpath=template_base_dir),

--- a/src/sabledocs/__main__.py
+++ b/src/sabledocs/__main__.py
@@ -30,7 +30,12 @@ def cli():
     # Execute the main processing of the Proto contracts.
     sable_context = parse_proto_descriptor(sable_config)
 
-    template_base_dir = sable_config.template if sable_config.template else os.path.join(os.path.dirname(__file__), "templates", "_default")
+    if sable_config.template != "_default":
+        print()
+        print('WARNING: The "template" config parameter is deprecated, it will be removed in a future version. The field template-path should be used instead.')
+        template_base_dir = f"templates/{sable_config.template}"
+    else:
+        template_base_dir = sable_config.template_path if sable_config.template_path else os.path.join(os.path.dirname(__file__), "templates", "_default")
 
     jinja_env = Environment(
         loader=FileSystemLoader(searchpath=template_base_dir),

--- a/src/sabledocs/sable_config.py
+++ b/src/sabledocs/sable_config.py
@@ -14,7 +14,7 @@ class SableConfig:
     def __init__(self, config_file_path):
         self.module_title = "Protobuf module documentation"
         self.input_descriptor_file = "descriptor.pb"
-        self.template = "_default"
+        self.template = ""
         self.footer_content = ""
         self.main_page_content_file = ""
         self.output_dir = "sabledocs_output"

--- a/src/sabledocs/sable_config.py
+++ b/src/sabledocs/sable_config.py
@@ -14,7 +14,8 @@ class SableConfig:
     def __init__(self, config_file_path):
         self.module_title = "Protobuf module documentation"
         self.input_descriptor_file = "descriptor.pb"
-        self.template = ""
+        self.template = "_default"
+        self.template_path = ""
         self.footer_content = ""
         self.main_page_content_file = ""
         self.output_dir = "sabledocs_output"
@@ -36,6 +37,8 @@ class SableConfig:
                 self.input_descriptor_file = config_values.get('input-descriptor-file', self.input_descriptor_file)
 
                 self.template = config_values.get('template', self.template).rstrip("/\\")
+
+                self.template_path = config_values.get('template-path', self.template_path).rstrip("/\\")
 
                 self.footer_content = config_values.get('footer-content', self.footer_content)
 


### PR DESCRIPTION
Details from here: https://github.com/markvincze/sabledocs/pull/20
>I see that the template directive is not exhibited in the sample sabledocs.toml. I'm guessing that's because you haven't finalized how that would work.
>
>I needed to use some different template files, and I ended up making this minor change.
>
>The default template directory _default/ now appears fewer times in the code, and if template is specified in the config file, it is no longer required to be a subdirectory of the current working directory (but it still could be).