### PR TITLE
Implement Markdown support in the package descriptions

### DIFF
--- a/src/sabledocs/proto_descriptor_parser.py
+++ b/src/sabledocs/proto_descriptor_parser.py
@@ -347,6 +347,7 @@ def parse_proto_descriptor(sable_config: SableConfig):
             ctx = ParseContext.New(sable_config, package, file.name, locations)
 
             package.description += ctx.GetComments(str(COMMENT_PACKAGE_INDEX))
+            package.description_html = markdown.markdown(package.description)
 
             parse_enums(file.enum_type, ctx.WithPath(COMMENT_ENUM_INDEX), None, "")
             parse_messages(file.message_type, ctx.WithPath(COMMENT_MESSAGE_INDEX), None, "")

--- a/src/sabledocs/templates/_default/package.html
+++ b/src/sabledocs/templates/_default/package.html
@@ -43,7 +43,7 @@
   </div>
 
   <div class="block">
-      {{ package.description | safe }}
+      {{ package.description_html | safe }}
   </div>
 
   {% if package.services %}


### PR DESCRIPTION
Addressing #18 

This was missed in the original implementation, the package description was not converted to HTML, so it was not supporting Markdown styling.
