### PR TITLE
Introduce Docker image with sabledocs to use in CI-builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
             python -m build -C--global-option=egg_info -C--global-option=--tag-build=".${CIRCLE_BUILD_NUM}dev"
             echo "Determining package version"
             package_base_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
-            echo "Package version: ${package_version}"
+            echo "Package version: ${package_base_version}"
             echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}dev0'" >> $BASH_ENV
             printenv PACKAGE_VERSION
             cp $BASH_ENV bash.env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ jobs:
           command: |
             pip install build
             python -m build -C--global-option=egg_info -C--global-option=--tag-build=".${CIRCLE_BUILD_NUM}dev"
+            package_base_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
+            export PACKAGE_VERSION="$package_base_version.${CIRCLE_BUILD_NUM}dev0"
       - persist_to_workspace:
           root: dist
           paths:
@@ -33,6 +35,8 @@ jobs:
           command: |
             pip install build
             python -m build -C--global-option=egg_info -C--global-option=--tag-build=".${CIRCLE_BUILD_NUM}"
+            package_base_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
+            export PACKAGE_VERSION="$package_base_version.${CIRCLE_BUILD_NUM}"
       - persist_to_workspace:
           root: dist
           paths:
@@ -78,14 +82,14 @@ jobs:
       # - python/install-packages:
       #     pkg-manager: pip
       #     app-dir: ~/project/src/sabledocs/
+            # package_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
+            # if [ "$CIRCLE_BRANCH" = "main" ]; then revision="${CIRCLE_BUILD_NUM}"; else revision="${CIRCLE_BUILD_NUM}dev0"; fi
       - setup_remote_docker:
           version: 20.10.14
       - run:
           command: |
-            package_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
-            if [ "$CIRCLE_BRANCH" = "main" ]; then revision="${CIRCLE_BUILD_NUM}"; else revision="${CIRCLE_BUILD_NUM}dev0"; fi
             protoc_version=$(curl -sL https://api.github.com/repos/protocolbuffers/protobuf/releases/latest | jq -r ".tag_name")
-            docker build -t markvincze/sabledocs:${package_version}.${revision} --build-arg sabledocs_version=${package_version}.${revision} --build-arg protoc_version=${protoc_version:1} .
+            docker build -t markvincze/sabledocs:${package_version}.${revision} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} .
 
 workflows:
   build-and-publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,13 +16,13 @@ jobs:
           name: Build Python package
           command: |
             pip install build
-            if [ $CIRCLE_BRANCH == "main" ]; then revision="${CIRCLE_BUILD_NUM}dev"; else revision="${CIRCLE_BUILD_NUM}"; fi
+            if [ $CIRCLE_BRANCH == "main" ]; then revision="${CIRCLE_BUILD_NUM}"; else revision="${CIRCLE_BUILD_NUM}dev"; fi
             python -m build -C--global-option=egg_info -C--global-option=--tag-build=".${revision}"
       - run:
           name: Persist package version in env var
           command: |
             package_base_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
-            if [ $CIRCLE_BRANCH == "main" ]; then package_version="$package_base_version.${CIRCLE_BUILD_NUM}.dev0"; else package_version="$package_base_version.${CIRCLE_BUILD_NUM}"; fi
+            if [ $CIRCLE_BRANCH == "main" ]; then package_version="$package_base_version.${CIRCLE_BUILD_NUM}"; else package_version="$package_base_version.${CIRCLE_BUILD_NUM}.dev0"; fi
             echo "export PACKAGE_VERSION='$package_version'" >> $BASH_ENV
             cp $BASH_ENV bash.env
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,9 @@ jobs:
             echo "Determining package version"
             package_base_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
             echo "Package version: ${package_base_version}"
+            echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}dev0'"
             echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}dev0'" >> $BASH_ENV
+            echo "Doing printenv"
             printenv PACKAGE_VERSION
             cp $BASH_ENV bash.env
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,9 +101,11 @@ jobs:
           version: 20.10.14
       - run:
           command: |
+            cat bash.env
+            echo $BASH_ENV
             cat bash.env >> $BASH_ENV
             protoc_version=$(curl -sL https://api.github.com/repos/protocolbuffers/protobuf/releases/latest | jq -r ".tag_name")
-            echo "docker build -t markvincze/sabledocs:${package_version}.${revision} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} ."
+            echo "docker build -t markvincze/sabledocs:${PACKAGE_VERSION} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} ."
             docker build -t markvincze/sabledocs:${PACKAGE_VERSION} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} .
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   python: circleci/python@1.5.0
 
 jobs:
-  build_dev:
+  build:
     docker:
       - image: cimg/python:3.11.3
     steps:
@@ -12,18 +12,18 @@ jobs:
       - python/install-packages:
           pkg-manager: pip
           app-dir: ~/project/src/sabledocs/
-          # export PACKAGE_VERSION="$package_base_version.${CIRCLE_BUILD_NUM}dev0"
-          # echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}dev0'" >> $BASH_ENV
       - run:
+          name: Build Python package
           command: |
             pip install build
-            python -m build -C--global-option=egg_info -C--global-option=--tag-build=".${CIRCLE_BUILD_NUM}dev"
-            echo "Determining package version"
+            if [ $CIRCLE_BRANCH == "main" ]; then revision="${CIRCLE_BUILD_NUM}dev"; else revision="${CIRCLE_BUILD_NUM}"; fi
+            python -m build -C--global-option=egg_info -C--global-option=--tag-build=".${revision}"
+      - run:
+          name: Persist package version in env var
+          command: |
             package_base_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
-            echo "Package version: ${package_base_version}"
-            echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}.dev0'"
-            echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}.dev0'" >> $BASH_ENV
-            echo "BASH_ENV: ${BASH_ENV}"
+            if [ $CIRCLE_BRANCH == "main" ]; then package_version="$package_base_version.${CIRCLE_BUILD_NUM}.dev0"; else package_version="$package_base_version.${CIRCLE_BUILD_NUM}"; fi
+            echo "export PACKAGE_VERSION='$package_version'" >> $BASH_ENV
             cp $BASH_ENV bash.env
       - persist_to_workspace:
           root: .
@@ -100,9 +100,7 @@ jobs:
       - run:
           name: Build and publish Docker image
           command: |
-            printenv PACKAGE_VERSION
             protoc_version=$(curl -sL https://api.github.com/repos/protocolbuffers/protobuf/releases/latest | jq -r ".tag_name")
-            echo "docker build -t markvincze/sabledocs:${PACKAGE_VERSION} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} ."
             image_tag=markvincze/sabledocs:${PACKAGE_VERSION}
             docker build -t ${image_tag} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} .
             echo "${DOCKERHUB_ACCESS_TOKEN}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
@@ -111,12 +109,14 @@ jobs:
 workflows:
   build-and-publish:
     jobs:
-      - build_dev:
+      - build:
+          name: build_dev
           filters:
             branches:
               ignore:
                 - main
-      - build_stable:
+      - build:
+          name: build_stable
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,23 @@ jobs:
             chmod +x generate_sample_docs.sh
             ./generate_sample_docs.sh
 
+  publish_docker_image:
+    docker:
+      - image: cimg/python:3.11.3
+    steps:
+      - checkout
+      # - add_ssh_keys:
+      #     fingerprints:
+      #       - "d5:12:33:42:6b:cd:57:b7:7f:08:2c:7a:a2:c4:54:6d"
+      # - python/install-packages:
+      #     pkg-manager: pip
+      #     app-dir: ~/project/src/sabledocs/
+      - run:
+          command: |
+            package_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
+            if [ "$CIRCLE_BRANCH" = "main" ]; then revision="${CIRCLE_BUILD_NUM}"; else revision="${CIRCLE_BUILD_NUM}dev0"; fi
+            docker build -t markvincze/sabledocs:${package_version}.${revision} .
+
 workflows:
   build-and-publish:
     jobs:
@@ -89,5 +106,13 @@ workflows:
           requires:
             - build_stable
       - generate_sample_docs:
+          requires:
+            - publish_pypi_stable
+      - publish_docker_image:
+          name: publish_docker_image_dev
+          requires:
+            - publish_pypi_dev
+      - publish_docker_image:
+          name: publish_docker_image_stable
           requires:
             - publish_pypi_stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,17 +12,21 @@ jobs:
       - python/install-packages:
           pkg-manager: pip
           app-dir: ~/project/src/sabledocs/
+          # export PACKAGE_VERSION="$package_base_version.${CIRCLE_BUILD_NUM}dev0"
+          # echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}dev0'" >> $BASH_ENV
       - run:
           command: |
             pip install build
             python -m build -C--global-option=egg_info -C--global-option=--tag-build=".${CIRCLE_BUILD_NUM}dev"
             package_base_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
-            export PACKAGE_VERSION="$package_base_version.${CIRCLE_BUILD_NUM}dev0"
             echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}dev0'" >> $BASH_ENV
+            printenv PACKAGE_VERSION
+            cp $BASH_ENV bash.env
       - persist_to_workspace:
-          root: dist
+          root: .
           paths:
-            - "*"
+            - "dist/*"
+            - "bash.env"
 
   build_stable:
     docker:
@@ -38,17 +42,20 @@ jobs:
             python -m build -C--global-option=egg_info -C--global-option=--tag-build=".${CIRCLE_BUILD_NUM}"
             package_base_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
             echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}'" >> $BASH_ENV
+            printenv PACKAGE_VERSION
+            cp $BASH_ENV bash.env
       - persist_to_workspace:
-          root: dist
+          root: .
           paths:
-            - "*"
+            - "dist/*"
+            - "bash.env"
 
   publish_pypi:
     docker:
       - image: cimg/python:3.11.3
     steps:
       - attach_workspace:
-          at: dist
+          at: .
       - run:
           command: |
             pip install twine
@@ -76,6 +83,8 @@ jobs:
     docker:
       - image: cimg/python:3.11.3
     steps:
+      - attach_workspace:
+          at: .
       - checkout
       # - add_ssh_keys:
       #     fingerprints:
@@ -89,9 +98,10 @@ jobs:
           version: 20.10.14
       - run:
           command: |
+            cat bash.env >> $BASH_ENV
             protoc_version=$(curl -sL https://api.github.com/repos/protocolbuffers/protobuf/releases/latest | jq -r ".tag_name")
             echo "docker build -t markvincze/sabledocs:${package_version}.${revision} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} ."
-            docker build -t markvincze/sabledocs:${package_version}.${revision} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} .
+            docker build -t markvincze/sabledocs:${PACKAGE_VERSION} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} .
 
 workflows:
   build-and-publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 
 orbs:
-  python: circleci/python@1.5.0
+  python: circleci/python@2.1.1
 
 jobs:
   build:
     docker:
-      - image: cimg/python:3.11.3
+      - image: cimg/python:3.12.0
     steps:
       - checkout
       - python/install-packages:
@@ -33,18 +33,19 @@ jobs:
 
   publish_pypi:
     docker:
-      - image: cimg/python:3.11.3
+      - image: cimg/python:3.12.0
     steps:
       - attach_workspace:
           at: .
       - run:
+          name: Publish Python package to PyPi
           command: |
             pip install twine
             python -m twine upload -u __token__ -p ${PYPI_API_TOKEN} ~/project/dist/*
 
   generate_sample_docs:
     docker:
-      - image: cimg/python:3.11.3
+      - image: cimg/python:3.12.0
     steps:
       - checkout
       - add_ssh_keys:
@@ -54,6 +55,7 @@ jobs:
           pkg-manager: pip
           app-dir: ~/project/src/sabledocs/
       - run:
+          name: Generate and publish the sample documentation
           command: |
             git config --global user.email "mrk.vincze@gmail.com"
             git config --global user.name "sabledocs CI"
@@ -62,7 +64,7 @@ jobs:
 
   publish_docker_image:
     docker:
-      - image: cimg/python:3.11.3
+      - image: cimg/python:3.12.0
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,28 +31,6 @@ jobs:
             - "dist/*"
             - "bash.env"
 
-  build_stable:
-    docker:
-      - image: cimg/python:3.11.3
-    steps:
-      - checkout
-      - python/install-packages:
-          pkg-manager: pip
-          app-dir: ~/project/src/sabledocs/
-      - run:
-          command: |
-            pip install build
-            python -m build -C--global-option=egg_info -C--global-option=--tag-build=".${CIRCLE_BUILD_NUM}"
-            package_base_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
-            echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}'" >> $BASH_ENV
-            printenv PACKAGE_VERSION
-            cp $BASH_ENV bash.env
-      - persist_to_workspace:
-          root: .
-          paths:
-            - "dist/*"
-            - "bash.env"
-
   publish_pypi:
     docker:
       - image: cimg/python:3.11.3
@@ -102,7 +80,8 @@ jobs:
           command: |
             protoc_version=$(curl -sL https://api.github.com/repos/protocolbuffers/protobuf/releases/latest | jq -r ".tag_name")
             image_tag=markvincze/sabledocs:${PACKAGE_VERSION}
-            docker build -t ${image_tag} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} .
+            if [ $CIRCLE_BRANCH == "main" ]; then latest_tag="-t markvincze/sabledocs:latest"; else latest_tag=""; fi
+            docker build -t ${image_tag} ${latest_tag} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} .
             echo "${DOCKERHUB_ACCESS_TOKEN}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
             docker push "${image_tag}"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,7 @@ jobs:
             cat bash.env
             echo $BASH_ENV
             cat bash.env >> $BASH_ENV
+            printenv PACKAGE_VERSION
             protoc_version=$(curl -sL https://api.github.com/repos/protocolbuffers/protobuf/releases/latest | jq -r ".tag_name")
             echo "docker build -t markvincze/sabledocs:${PACKAGE_VERSION} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} ."
             docker build -t markvincze/sabledocs:${PACKAGE_VERSION} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,7 @@ jobs:
       - run:
           command: |
             protoc_version=$(curl -sL https://api.github.com/repos/protocolbuffers/protobuf/releases/latest | jq -r ".tag_name")
+            echo "docker build -t markvincze/sabledocs:${package_version}.${revision} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} ."
             docker build -t markvincze/sabledocs:${package_version}.${revision} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} .
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,8 @@ jobs:
       # - python/install-packages:
       #     pkg-manager: pip
       #     app-dir: ~/project/src/sabledocs/
+      - setup_remote_docker:
+          version: 20.10.14
       - run:
           command: |
             package_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,9 +86,9 @@ jobs:
     docker:
       - image: cimg/python:3.11.3
     steps:
+      - checkout
       - attach_workspace:
           at: .
-      - checkout
       # - add_ssh_keys:
       #     fingerprints:
       #       - "d5:12:33:42:6b:cd:57:b7:7f:08:2c:7a:a2:c4:54:6d"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
             python -m build -C--global-option=egg_info -C--global-option=--tag-build=".${CIRCLE_BUILD_NUM}dev"
             package_base_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
             export PACKAGE_VERSION="$package_base_version.${CIRCLE_BUILD_NUM}dev0"
+            echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}dev0'" >> $BASH_ENV
       - persist_to_workspace:
           root: dist
           paths:
@@ -36,7 +37,7 @@ jobs:
             pip install build
             python -m build -C--global-option=egg_info -C--global-option=--tag-build=".${CIRCLE_BUILD_NUM}"
             package_base_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
-            export PACKAGE_VERSION="$package_base_version.${CIRCLE_BUILD_NUM}"
+            echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}'" >> $BASH_ENV
       - persist_to_workspace:
           root: dist
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,27 +89,24 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      # - add_ssh_keys:
-      #     fingerprints:
-      #       - "d5:12:33:42:6b:cd:57:b7:7f:08:2c:7a:a2:c4:54:6d"
-      # - python/install-packages:
-      #     pkg-manager: pip
-      #     app-dir: ~/project/src/sabledocs/
-            # package_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
-            # if [ "$CIRCLE_BRANCH" = "main" ]; then revision="${CIRCLE_BUILD_NUM}"; else revision="${CIRCLE_BUILD_NUM}dev0"; fi
       - setup_remote_docker:
           version: 20.10.14
       - run:
+          name: Restore environment variables
           command: |
             cat bash.env
             echo $BASH_ENV
             cat bash.env >> $BASH_ENV
       - run:
+          name: Build and publish Docker image
           command: |
             printenv PACKAGE_VERSION
             protoc_version=$(curl -sL https://api.github.com/repos/protocolbuffers/protobuf/releases/latest | jq -r ".tag_name")
             echo "docker build -t markvincze/sabledocs:${PACKAGE_VERSION} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} ."
-            docker build -t markvincze/sabledocs:${PACKAGE_VERSION} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} .
+            image_tag=markvincze/sabledocs:${PACKAGE_VERSION}
+            docker build -t ${image_tag} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} .
+            echo "${DOCKERHUB_ACCESS_TOKEN}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
+            docker push "${image_tag}"
 
 workflows:
   build-and-publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,8 @@ jobs:
           command: |
             package_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
             if [ "$CIRCLE_BRANCH" = "main" ]; then revision="${CIRCLE_BUILD_NUM}"; else revision="${CIRCLE_BUILD_NUM}dev0"; fi
-            docker build -t markvincze/sabledocs:${package_version}.${revision} .
+            protoc_version=$(curl -sL https://api.github.com/repos/protocolbuffers/protobuf/releases/latest | jq -r ".tag_name")
+            docker build -t markvincze/sabledocs:${package_version}.${revision} --build-arg sabledocs_version=${package_version}.${revision} --build-arg protoc_version=${protoc_version:1} .
 
 workflows:
   build-and-publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,9 @@ jobs:
           command: |
             pip install build
             python -m build -C--global-option=egg_info -C--global-option=--tag-build=".${CIRCLE_BUILD_NUM}dev"
+            echo "Determining package version"
             package_base_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
+            echo "Package version: ${package_version}"
             echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}dev0'" >> $BASH_ENV
             printenv PACKAGE_VERSION
             cp $BASH_ENV bash.env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,8 @@ jobs:
             cat bash.env
             echo $BASH_ENV
             cat bash.env >> $BASH_ENV
+      - run:
+          command: |
             printenv PACKAGE_VERSION
             protoc_version=$(curl -sL https://api.github.com/repos/protocolbuffers/protobuf/releases/latest | jq -r ".tag_name")
             echo "docker build -t markvincze/sabledocs:${PACKAGE_VERSION} --build-arg sabledocs_version=${PACKAGE_VERSION} --build-arg protoc_version=${protoc_version:1} ."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,9 @@ jobs:
             echo "Determining package version"
             package_base_version=$(grep 'version =' pyproject.toml | sed -e 's/version = "\(.*\)"/\1/')
             echo "Package version: ${package_base_version}"
-            echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}dev0'"
-            echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}dev0'" >> $BASH_ENV
-            echo "Doing printenv"
-            printenv PACKAGE_VERSION
+            echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}.dev0'"
+            echo "export PACKAGE_VERSION='$package_base_version.${CIRCLE_BUILD_NUM}.dev0'" >> $BASH_ENV
+            echo "BASH_ENV: ${BASH_ENV}"
             cp $BASH_ENV bash.env
       - persist_to_workspace:
           root: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12.0
+
+ARG sabledocs_version
+ARG protoc_version
+
+RUN apt update && \
+    apt install -y jq && \
+    #protoc_version=$(curl -sL https://api.github.com/repos/protocolbuffers/protobuf/releases/latest | jq -r ".tag_name") && \
+    wget https://github.com/protocolbuffers/protobuf/releases/download/v${protoc_version}/protoc-${protoc_version}-linux-x86_64.zip && \
+    unzip -q protoc-${protoc_version}-linux-x86_64.zip -d ./protoc && \
+    cp ./protoc/bin/protoc /bin && \
+    pip install sabledocs==${sabledocs_version}
+
+    #wget https://github.com/protocolbuffers/protobuf/releases/download/${protoc_version}/protoc-${protoc_version:1}-linux-x86_64.zip
+    #unzip -q protoc-${protoc_version}-linux-x86_64.zip -d ./protoc && \
+    #cp ./protoc/bin/protoc /bin && \
+    #pip install sabledocs==${sabledocs_version}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,7 @@ ARG protoc_version
 
 RUN apt update && \
     apt install -y jq && \
-    #protoc_version=$(curl -sL https://api.github.com/repos/protocolbuffers/protobuf/releases/latest | jq -r ".tag_name") && \
     wget https://github.com/protocolbuffers/protobuf/releases/download/v${protoc_version}/protoc-${protoc_version}-linux-x86_64.zip && \
     unzip -q protoc-${protoc_version}-linux-x86_64.zip -d ./protoc && \
     cp ./protoc/bin/protoc /bin && \
     pip install sabledocs==${sabledocs_version}
-
-    #wget https://github.com/protocolbuffers/protobuf/releases/download/${protoc_version}/protoc-${protoc_version:1}-linux-x86_64.zip
-    #unzip -q protoc-${protoc_version}-linux-x86_64.zip -d ./protoc && \
-    #cp ./protoc/bin/protoc /bin && \
-    #pip install sabledocs==${sabledocs_version}


### PR DESCRIPTION
Introduce a Docker image with `protoc` and the `sabledocs` CLI pre-installed, and add it to the CI-build.

Addresses #22 