### PR TITLE
fix code background color

### DIFF
--- a/sass/mystyles.scss
+++ b/sass/mystyles.scss
@@ -125,6 +125,10 @@ body.dark input.input::placeholder {
   color: #565656;
 }
 
+body.dark pre {
+  background: #2A2A2A;
+}
+
 body.dark code {
   background: #2A2A2A;
   color: #569cd6;


### PR DESCRIPTION
Thanks for creating this useful project! Here's a small fix:

Code in proto comments like this:

```
syntax = "proto3";

package sable.test.v1;

// Example 1: Compute Timestamp from POSIX `time()`.
//
//     Timestamp timestamp;
//     timestamp.set_seconds(time(NULL));
//     timestamp.set_nanos(0);
//
message SmallMessage {
    string foo = 1;
}
```

Which you find in places like [this](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/timestamp.proto#L59).

Render like this in dark mode:

![code-in-darkmode-current](https://github.com/markvincze/sabledocs/assets/315342/349db409-d104-4111-8744-72c1d2d308c7)

This change makes them render like this instead:

![code-in-darkmode-fixed](https://github.com/markvincze/sabledocs/assets/315342/da235cf8-e375-4e2d-8d11-8b1549a49e49)

