### PR TITLE
add support for repository-dir in code urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ footer-content = "© 2023 Jane Doe. All rights reserved."
 # code. By default these fields are not configured, and source code links are not included in the docs.
 # The repository-type field supports two possible values, "github" and "bitbucket".
 # The fields repository-url and repository-branch should be configured to point to the correct repository.
+# repository-dir should be set only if the root of your Protobuf module is in a specific directory inside your repository.
 repository-type = "github"
 repository-url = "https://github.com/janedoe/myawesomeproject"
 repository-branch = "main"
+repository-dir = "proto"
 
 # In each comment, ignore everything that comes after (until end of the comment) one of the keywords.
 # Default value: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sabledocs"
-version = "0.9"
+version = "0.10"
 authors = [
   { name="Mark Vincze", email="mrk.vincze@gmail.com" },
 ]
@@ -16,6 +16,7 @@ dependencies = [
   "Markdown==3.4.1",
   "protobuf==4.21.6",
   "lunr==0.6.2",
+  "furl==2.1.3",
 ]
 classifiers = [
     "Programming Language :: Python :: 3.11",

--- a/src/sabledocs/sable_config.py
+++ b/src/sabledocs/sable_config.py
@@ -27,6 +27,7 @@ class SableConfig:
         self.enable_lunr_search = True
         self.repository_url = ""
         self.repository_branch = ""
+        self.repository_dir = ""
         self.repository_type = RepositoryType.NONE
         self.ignore_comments_after: List[str] = []
         self.ignore_comment_lines_containing: List[str] = []
@@ -48,6 +49,7 @@ class SableConfig:
                 self.enable_lunr_search = config_values.get('enable-lunr-search', True)
                 self.repository_url = config_values.get('repository-url', self.repository_url)
                 self.repository_branch = config_values.get('repository-branch', self.repository_branch)
+                self.repository_dir = config_values.get('repository-dir', self.repository_dir)
 
                 if 'repository-type' in config_values:
                     match config_values['repository-type']:

--- a/tests/test_proto_descriptor_parser.py
+++ b/tests/test_proto_descriptor_parser.py
@@ -1,0 +1,90 @@
+import unittest
+
+from sabledocs.sable_config import RepositoryType
+from sabledocs.proto_descriptor_parser import build_source_code_url
+
+class TestProtoDescriptorParser(unittest.TestCase):
+
+    def test_code_url_github_style(self):
+
+        got = build_source_code_url(
+                'https://git.example.com',
+                RepositoryType.GITHUB,
+                "main",
+                "", # no repository_dir
+                "foo/bar.proto",
+                41)
+
+        expected = 'https://git.example.com/blob/main/foo/bar.proto#L41'
+
+        self.assertEqual(got, expected)
+
+    def test_code_url_github_style_with_repo_dir(self):
+
+        got = build_source_code_url(
+                'https://git.example.com',
+                RepositoryType.GITHUB,
+                "main",
+                "myrepodir",
+                "foo/bar.proto",
+                41)
+
+        expected = 'https://git.example.com/blob/main/myrepodir/foo/bar.proto#L41'
+
+        self.assertEqual(got, expected)
+
+    def test_code_url_github_style_extra_slashes(self):
+
+        got = build_source_code_url(
+                'https://git.example.com/',
+                RepositoryType.GITHUB,
+                "main",
+                "/myrepodir/",
+                "/foo/bar.proto",
+                41)
+
+        expected = 'https://git.example.com/blob/main/myrepodir/foo/bar.proto#L41'
+
+        self.assertEqual(got, expected)
+
+    def test_code_url_bitbucket_style(self):
+
+        got = build_source_code_url(
+                'https://git.example.com',
+                RepositoryType.BITBUCKET,
+                "main",
+                "", # no repository_dir
+                "foo/bar.proto",
+                41)
+
+        expected = 'https://git.example.com/src/main/foo/bar.proto#lines-42'
+
+        self.assertEqual(got, expected)
+
+    def test_code_url_bitbucket_style_with_repo_dir(self):
+
+        got = build_source_code_url(
+                'https://git.example.com',
+                RepositoryType.BITBUCKET,
+                "main",
+                "myrepodir",
+                "foo/bar.proto",
+                41)
+
+        expected = 'https://git.example.com/src/main/myrepodir/foo/bar.proto#lines-42'
+
+        self.assertEqual(got, expected)
+
+    def test_code_url_bitbucket_style_extra_slashes(self):
+
+        got = build_source_code_url(
+                'https://git.example.com/',
+                RepositoryType.BITBUCKET,
+                "main",
+                "/myrepodir/",
+                "/foo/bar.proto",
+                41)
+
+        expected = 'https://git.example.com/src/main/myrepodir/foo/bar.proto#lines-42'
+
+        self.assertEqual(got, expected)


### PR DESCRIPTION
Sometimes your proto files are inside a specific directory in your git repo. At least mine are. This PR adds support for the config value `repository-dir`. That makes links from docs to protos work correctly in this situation.

Note: I used `furl` in `build_source_code_url` to try and keep things tidy. That's an extra dependency though. I'd be happy to give you a string-template-style implementation if you like that better. I added some tests for that to hopefully make it clear that my changes there don't break anything.