### PR TITLE
allow the "Default Value" column to be turned off

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ hidden-packages = ["google.protobuf"]
 # were listed in the input when `protoc` was executed.
 # Default value: ""
 member-ordering = "preserve"
+
+# By default, message documentation includes the "Default Value" column. Set show-default-value to
+# false if you don't want that column.
+show-default-value = true
 ```
 
 ### Main page content

--- a/src/sabledocs/sable_config.py
+++ b/src/sabledocs/sable_config.py
@@ -32,6 +32,7 @@ class SableConfig:
         self.ignore_comment_lines_containing: List[str] = []
         self.hidden_packages: List[str] = []
         self.member_ordering = MemberOrdering.ALPHABETICAL
+        self.show_default_value = True
 
         if path.exists(config_file_path):
             print(f"Configuration found in {config_file_path}")
@@ -63,5 +64,7 @@ class SableConfig:
                 if 'member-ordering' in config_values:
                     if config_values["member-ordering"] == "preserve":
                         self.member_ordering = MemberOrdering.PRESERVE_ORIGINAL
+
+                self.show_default_value = config_values.get('show-default-value', self.show_default_value)
         else:
             print("sabledocs.toml file not found, using default configuration.")

--- a/src/sabledocs/templates/_default/message.html
+++ b/src/sabledocs/templates/_default/message.html
@@ -23,7 +23,9 @@
       <th>Field</th>
       <th>Type</th>
       <th>Description</th>
+      {% if sable_config.show_default_value %}
       <th>Default Value</th>
+      {% endif %}
     </tr>
   </thead>
   <tbody>
@@ -42,7 +44,9 @@
         </code>
       </td>
       <td class="content">{{ field.description_html | safe }}</td>
+      {% if sable_config.show_default_value %}
       <td>{{ field.default_value }}</td>
+      {% endif %}
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
In the rendered docs that I've seen the "Default Value" column for messages is always empty. This PR adds a config field `show-default-value` that lets you disable that column. 