### PR TITLE
Add capability to hide the default column if it's not needed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sabledocs"
-version = "0.10"
+version = "0.11"
 authors = [
   { name="Mark Vincze", email="mrk.vincze@gmail.com" },
 ]

--- a/src/sabledocs/proto_model.py
+++ b/src/sabledocs/proto_model.py
@@ -41,6 +41,10 @@ class Message(CodeItem):
     @property
     def full_type(self):
         return self.full_name
+    
+    @property
+    def has_any_fields_with_default_value(self):
+        return any(filter(lambda f: f.default_value, self.fields))
 
     def __repr__(self):
         return pformat(vars(self), indent=4, width=1)

--- a/src/sabledocs/templates/_default/message.html
+++ b/src/sabledocs/templates/_default/message.html
@@ -23,7 +23,9 @@
       <th>Field</th>
       <th>Type</th>
       <th>Description</th>
+      {% if message.has_any_fields_with_default_value %}
       <th>Default Value</th>
+      {% endif %}
     </tr>
   </thead>
   <tbody>
@@ -42,7 +44,9 @@
         </code>
       </td>
       <td class="content">{{ field.description_html | safe }}</td>
+      {% if message.has_any_fields_with_default_value %}
       <td>{{ field.default_value }}</td>
+      {% endif %}
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
There is no point in displaying the "Default value" column if the message does not have any fields with default values. Which applies to all proto3 contracts, as default values are not even supported in version 3.

This PR adds logic to hide the column if the message does not have any fields with default values.