### PR TITLE
Hide hidden packages from search results, and handle links correctly

### DIFF
--- a/src/sabledocs/__main__.py
+++ b/src/sabledocs/__main__.py
@@ -53,7 +53,7 @@ def cli():
         os.makedirs(sable_config.output_dir)
 
     # NOTE: When the output files are generated, the encode('utf-8') option has to be used, otherwise Unicode characters like © can end up garbled.
-    for package in sable_context.packages:
+    for package in sable_context.non_hidden_packages:
         with open(os.path.join(sable_config.output_dir, f'{package.name if package.name else "__default"}.html'), 'wb') as fh:
             output = package_template.render(
                 sable_config=sable_config,

--- a/src/sabledocs/lunr_search.py
+++ b/src/sabledocs/lunr_search.py
@@ -5,7 +5,7 @@ from sabledocs.proto_model import Enum, Message, Package, SableContext, Service
 def build_search_index(sable_context: SableContext) -> tuple[dict[str, dict[str, str]], lunr.index.Index]:
     documents = []
 
-    for package in sable_context.packages:
+    for package in sable_context.non_hidden_packages:
         doc = {
             "package": package.name,
             "url": f"{package.name}.html",

--- a/src/sabledocs/proto_descriptor_parser.py
+++ b/src/sabledocs/proto_descriptor_parser.py
@@ -268,7 +268,7 @@ def extract_package_name_from_full_name(full_type_name: str):
         return full_type_name[:last_dot]
 
 
-def add_package_references(messages: list[Message], services: list[Service], packages: list[Package]):
+def add_package_references(messages: list[Message], services: list[Service], packages: list[Package], hidden_packages: list[str]):
     for m in messages:
         package = next(filter(lambda p: m.full_name.startswith(p.name), packages), None)
         if package is not None:
@@ -281,10 +281,7 @@ def add_package_references(messages: list[Message], services: list[Service], pac
             package = next(filter(lambda p: mf.full_type.startswith(p.name), packages), None)
             if package is not None:
                 mf.package = package
-
-            package = next(filter(lambda p: mf.full_type.startswith(p.name), packages), None)
-            if package is not None:
-                mf.package = package
+                mf.is_package_hidden = any(filter(lambda p: mf.full_type.startswith(p), hidden_packages))
 
     for s in services:
         for sm in s.methods:
@@ -389,7 +386,7 @@ def parse_proto_descriptor(sable_config: SableConfig):
 
             packages[file.package] = package
 
-        add_package_references(all_messages, all_services, list(packages.values()))
+        add_package_references(all_messages, all_services, list(packages.values()), sable_config.hidden_packages)
 
         return SableContext(
             sorted(packages.values(), key=lambda p: (p.name))

--- a/src/sabledocs/proto_model.py
+++ b/src/sabledocs/proto_model.py
@@ -22,6 +22,7 @@ class MessageField(CodeItem):
         self.full_type = ''
         self.default_value = ''
         self.package: Optional[Package] = None
+        self.is_package_hidden = False
         self.type_kind = "UNKNOWN"
         self.oneof_name: Optional[str] = None
 

--- a/src/sabledocs/templates/_default/type_name.html
+++ b/src/sabledocs/templates/_default/type_name.html
@@ -1,6 +1,6 @@
 ## The %- and -% syntax is used everywhere to trim all the whitespace, to make sure no extra unwanted spaces are around the type name, for example if it's displayed between parens.
 {%- macro type_name(message_field) -%}
-  {%- if message_field.package and message_field.type_kind != "UNKNOWN" -%}
+  {%- if message_field.package and not message_field.is_package_hidden and message_field.type_kind != "UNKNOWN" -%}
     {%- if message_field.type_kind == "MESSAGE" -%}
       <a href="{{ message_field.package.name if message_field.package.name else "__default" }}.html#message-{{ message_field.full_type }}">
     {%- else -%}


### PR DESCRIPTION
Addressing #65 

The PR changes the logic so that `hidden_packages` is taken into account when generating links for the type names, generating the html files for the packages, and creating the search index.