### PR TITLE
feat: add included-to-main option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ ignore-comment-lines-containing = ["buf:lint"]
 # Default value: []
 hidden-packages = ["google.protobuf"]
 
+# Packages can be hidden from the index.html file but still be accessible as links from othes packages
+hidden-from-main-packages = ["google.struct"]
+
 # By default, packages and members in a package are ordered alphabetically.
 # By setting the member-ordering option to "preserve", the original order present in the Protobuf
 # definitions will be preserved.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ ignore-comment-lines-containing = ["buf:lint"]
 # Default value: []
 hidden-packages = ["google.protobuf"]
 
-# Packages can be hidden from the index.html file but still be accessible as links from othes packages
+# Packages can be hidden from the index.html file, but still will be accessible as links from other packages.
 hidden-from-main-packages = ["google.struct"]
 
 # By default, packages and members in a package are ordered alphabetically.

--- a/src/sabledocs/proto_descriptor_parser.py
+++ b/src/sabledocs/proto_descriptor_parser.py
@@ -370,6 +370,7 @@ def parse_proto_descriptor(sable_config: SableConfig):
 
             package = packages.get(file.package, Package())
             package.name = file.package
+            package.is_hidden_from_main = package.name in sable_config.hidden_from_main_packages
 
             ctx = ParseContext.New(sable_config, package, file.name, locations)
 

--- a/src/sabledocs/proto_model.py
+++ b/src/sabledocs/proto_model.py
@@ -112,6 +112,7 @@ class Package(CodeItem):
         self.messages = []
         self.enums = []
         self.services = []
+        self.is_hidden_from_main = False
 
     def __repr__(self):
         return pformat(vars(self), indent=4, width=1)

--- a/src/sabledocs/sable_config.py
+++ b/src/sabledocs/sable_config.py
@@ -34,6 +34,7 @@ class SableConfig:
         self.ignore_comments_after: List[str] = []
         self.ignore_comment_lines_containing: List[str] = []
         self.hidden_packages: List[str] = []
+        self.hidden_from_main_packages: List[str] = []
         self.member_ordering = MemberOrdering.ALPHABETICAL
         self.markdown_extensions: List[str] = ['fenced_code']
 
@@ -68,6 +69,7 @@ class SableConfig:
                 self.ignore_comments_after = config_values.get('ignore-comments-after', [])
                 self.ignore_comment_lines_containing = config_values.get('ignore-comment-lines-containing', [])
                 self.hidden_packages = config_values.get('hidden-packages', [])
+                self.hidden_from_main_packages = config_values.get('hidden-from-main-packages', [])
                 self.markdown_extensions = config_values.get('markdown-extensions', self.markdown_extensions)
 
                 if 'member-ordering' in config_values:

--- a/src/sabledocs/templates/_default/index.html
+++ b/src/sabledocs/templates/_default/index.html
@@ -12,17 +12,19 @@
   <div class="block">This site contains the documentation for the following Protobuf packages.</div>
   <div class="block">
   {% for p in non_hidden_packages %}
-    <h5 class="title is-5">
-      {% if p.name %}
-        <a href="{{ p.name }}.html">{{ p.name }}</a>
-      {% else %}
-        <a href="__default.html">(Default package)</a>
+    {% if not p.is_hidden_from_main%}
+      <h5 class="title is-5">
+        {% if p.name %}
+          <a href="{{ p.name }}.html">{{ p.name }}</a>
+        {% else %}
+          <a href="__default.html">(Default package)</a>
+        {% endif %}
+      </h4>
+      {% if p.description_html %}
+      <div style="margin-top: -0.5rem; margin-bottom: 2.5rem">
+        {{ p.description_html | safe }}
+      </div>
       {% endif %}
-    </h4>
-    {% if p.description_html %}
-    <div style="margin-top: -0.5rem; margin-bottom: 2.5rem">
-      {{ p.description_html | safe }}
-    </div>
     {% endif %}
   {% endfor %}
   </div>


### PR DESCRIPTION
This PR will add possibility to add packages which are clickable as links in another packages description, but are not displayed in index.html