### PR TITLE
implements hooks for additional processing of comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,24 @@ template-path = "extra-templates"
 template-path-suffix = ".tpl" # default value is ".html"
 ```
 
+### Custom Parsing of Comments
+
+In some cases, it may be desirable to implement additional processing on the comment strings before inserting them into the HTML document.
+
+PLEASE NOTE: This is an advanced feature that some have used to embed additional machine-parseable information into a `.proto` file.
+Users should be aware that use of this feature will probably make it harder to formatting options that `sabledocs` implements, especially those that are white-space sensitive.
+
+It is activated by indicating a python script defining a class that inherits from [CommentsParser](src/sabledocs/comments_parser.py).
+This class will be instantiated by `sabledocs` and its methods invoked to pre-process the comment strings that have been collected for
+`Message`s, `Field`s, `Enum`s, `EnumValue`s, `Service`s, and `ServiceMethod`s.
+Or, processing of all of these different entities can be indicate by reimplementing `CommentsParser.ParseAll()`.
+
+An example of using this feature to process comments formatted as JSON strings can be found at [sample/custom_comments_parser.py].
+
+```toml
+comments-parser-file = sample/custom_comments_parser.py
+```
+
 ### Using with Docker
 
 For convenient usage in CI builds and other scenarios where a Docker image is preferable, the image [`markvincze/sabledocs`](https://hub.docker.com/r/markvincze/sabledocs) can be used, which has both the `protoc` CLI, and `sabledocs` preinstalled.

--- a/README.md
+++ b/README.md
@@ -184,13 +184,13 @@ Users should be aware that use of this feature will probably make it harder to f
 
 It is activated by indicating a python script defining a class that inherits from [CommentsParser](src/sabledocs/comments_parser.py).
 This class will be instantiated by `sabledocs` and its methods invoked to pre-process the comment strings that have been collected for
-`Message`s, `Field`s, `Enum`s, `EnumValue`s, `Service`s, and `ServiceMethod`s.
+Messages, Fields, Enums, EnumValues, Services, and ServiceMethods.
 Or, processing of all of these different entities can be indicate by reimplementing `CommentsParser.ParseAll()`.
 
-An example of using this feature to process comments formatted as JSON strings can be found at [sample/custom_comments_parser.py].
+An example of using this feature to process comments formatted as JSON strings can be found at (custom_comments_parser.py)[sample/custom_comments_parser.py].
 
 ```toml
-comments-parser-file = sample/custom_comments_parser.py
+comments-parser-file = "sample/custom_comments_parser.py"
 ```
 
 ### Using with Docker

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ This class will be instantiated by `sabledocs` and its methods invoked to pre-pr
 Messages, Fields, Enums, EnumValues, Services, and ServiceMethods.
 Or, processing of all of these different entities can be indicate by reimplementing `CommentsParser.ParseAll()`.
 
-An example of using this feature to process comments formatted as JSON strings can be found at (custom_comments_parser.py)[sample/custom_comments_parser.py].
+An example of using this feature to process comments formatted as JSON strings can be found at [custom_comments_parser.py](sample/custom_comments_parser.py).
 
 ```toml
 comments-parser-file = "sample/custom_comments_parser.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sabledocs"
-version = "0.14"
+version = "0.15"
 authors = [
   { name="Mark Vincze", email="mrk.vincze@gmail.com" },
 ]

--- a/sample/custom_comments_parser.py
+++ b/sample/custom_comments_parser.py
@@ -1,0 +1,21 @@
+
+import json
+import re
+
+class CustomCommentsParser(CommentsParser):
+    def __init__(self):
+        pass
+
+    def ParseAll(self, comment):
+        comment_simple = ' '.join(comment.split()) # remove all new lines and duplicate spaces before json parse
+        try:
+            comments_dict = json.loads(comment_simple)
+        except json.decoder.JSONDecodeError:
+            # could print an error here if comments_simple starts with '{' or something
+            pass
+        else:
+            if "desc" in comments_dict:
+                # wherever there was a "<p>" replace that with "\n\n" for (utimately) HTML formatting as a new paragraph
+                comment = re.sub(r'<p>', r'\n\n', comments_dict["desc"])
+
+        return comment

--- a/sample/sabledocs.toml
+++ b/sample/sabledocs.toml
@@ -13,4 +13,4 @@ footer-content = "© Example 2023"
 repository-url = "https://github.com/googleapis/googleapis"
 repository-type = "github"
 repository-branch = "master"
-#comments-parser-file = sample/custom_comments_parser.py
+#comments-parser-file = "sample/custom_comments_parser.py"

--- a/sample/sabledocs.toml
+++ b/sample/sabledocs.toml
@@ -13,4 +13,4 @@ footer-content = "© Example 2023"
 repository-url = "https://github.com/googleapis/googleapis"
 repository-type = "github"
 repository-branch = "master"
-#comments-parser-file = 
+#comments-parser-file = sample/custom_comments_parser.py

--- a/sample/sabledocs.toml
+++ b/sample/sabledocs.toml
@@ -13,3 +13,4 @@ footer-content = "© Example 2023"
 repository-url = "https://github.com/googleapis/googleapis"
 repository-type = "github"
 repository-branch = "master"
+#comments-parser-file = 

--- a/src/sabledocs/comments_parser.py
+++ b/src/sabledocs/comments_parser.py
@@ -1,0 +1,30 @@
+
+class CommentsParser:
+    """Inherit from this class in order to provide additional parsing of
+       comment strings before inserting into the HTML document."""
+    def __init__(self):
+        pass
+
+    def ParseAll(self, comment):
+        return comment
+
+    def ParsePackage(self, comment):
+        return self.ParseAll(comment)
+
+    def ParseMessage(self, comment):
+        return self.ParseAll(comment)
+
+    def ParseField(self, comment):
+        return self.ParseAll(comment)
+
+    def ParseEnum(self, comment):
+        return self.ParseAll(comment)
+
+    def ParseEnumValue(self, comment):
+        return self.ParseAll(comment)
+
+    def ParseService(self, comment):
+        return self.ParseAll(comment)
+
+    def ParseServiceMethod(self, comment):
+        return self.ParseAll(comment)

--- a/src/sabledocs/proto_descriptor_parser.py
+++ b/src/sabledocs/proto_descriptor_parser.py
@@ -8,7 +8,6 @@ from google.protobuf.descriptor_pb2 import ServiceDescriptorProto
 from google.protobuf.descriptor_pb2 import MethodDescriptorProto
 from sabledocs.proto_model import MessageField, Message, EnumValue, Enum, OneOfFieldGroup, ServiceMethod, ServiceMethodArgument, Service, Package, LocationInfo, SableContext
 from sabledocs.sable_config import MemberOrdering, RepositoryType, SableConfig
-from sabledocs.comments_parser import CommentsParser
 import pprint
 import markdown
 import pprint
@@ -94,12 +93,12 @@ class ParseContext:
         return 0 if location is None else location.line_number
 
 
-def parse_enum(enum: EnumDescriptorProto, ctx: ParseContext, parent_message, nested_type_chain: str, config: SableConfig):
-    def parse_enum_value(enum_value: EnumValueDescriptorProto, ctx: ParseContext, config: SableConfig):
+def parse_enum(enum: EnumDescriptorProto, ctx: ParseContext, parent_message, nested_type_chain: str):
+    def parse_enum_value(enum_value: EnumValueDescriptorProto, ctx: ParseContext):
         ev = EnumValue()
         ev.name = enum_value.name
         ev.number = enum_value.number
-        ev.description = config.comments_parser.ParseEnumValue(ctx.GetComments())
+        ev.description = ctx.config.comments_parser.ParseEnumValue(ctx.GetComments())
         ev.description_html = markdown_to_html(ev.description, ctx.config)
         ev.line_number = ctx.GetLineNumber()
 
@@ -109,7 +108,7 @@ def parse_enum(enum: EnumDescriptorProto, ctx: ParseContext, parent_message, nes
     e.name = enum.name
     e.full_name = f"{ctx.package.name}.{nested_type_chain}{enum.name}".lstrip(".")
     e.parent_message = parent_message
-    e.description = config.comments_parser.ParseEnum(ctx.GetComments())
+    e.description = ctx.config.comments_parser.ParseEnum(ctx.GetComments())
     e.description_html = markdown_to_html(e.description, ctx.config)
     e.source_file_path = ctx.source_file_path
     e.line_number = ctx.GetLineNumber()
@@ -122,26 +121,26 @@ def parse_enum(enum: EnumDescriptorProto, ctx: ParseContext, parent_message, nes
         e.line_number)
 
     for i, ev in enumerate(enum.value):
-        e.values.append(parse_enum_value(ev, ctx.ExtendPath(COMMENT_ENUM_VALUE_INDEX, i), config))
+        e.values.append(parse_enum_value(ev, ctx.ExtendPath(COMMENT_ENUM_VALUE_INDEX, i)))
 
     return e
 
 
-def parse_enums(enums: Sequence[EnumDescriptorProto], ctx: ParseContext, parent_message, nested_type_chain: str, config: SableConfig):
+def parse_enums(enums: Sequence[EnumDescriptorProto], ctx: ParseContext, parent_message, nested_type_chain: str):
     for (i, enum) in enumerate(enums):
-        ctx.package.enums.append(parse_enum(enum, ctx.ExtendPath(i), parent_message, nested_type_chain, config))
+        ctx.package.enums.append(parse_enum(enum, ctx.ExtendPath(i), parent_message, nested_type_chain))
 
-    if config.member_ordering == MemberOrdering.ALPHABETICAL:
+    if ctx.config.member_ordering == MemberOrdering.ALPHABETICAL:
         ctx.package.enums.sort(key=lambda e: e.name)
 
 
-def parse_field(field: FieldDescriptorProto, containing_message: DescriptorProto, ctx: ParseContext, config: SableConfig):
+def parse_field(field: FieldDescriptorProto, containing_message: DescriptorProto, ctx: ParseContext):
     mf = MessageField()
     mf.name = field.name
 
     mf.number = field.number
     mf.label = to_label_name(field.label, field.proto3_optional)
-    mf.description = config.comments_parser.ParseField(ctx.GetComments())
+    mf.description = ctx.config.comments_parser.ParseField(ctx.GetComments())
     mf.description_html = markdown_to_html(mf.description, ctx.config)
     mf.line_number = ctx.GetLineNumber()
     mf.full_type = field.type_name.strip(".") if field.type_name != "" else to_type_name(field.type)
@@ -172,12 +171,12 @@ def extract_type_name_from_full_name(full_type_name: str):
         return full_type_name[last_dot + 1:]
 
 
-def parse_message(message: DescriptorProto, ctx: ParseContext, parent_message, nested_type_chain: str, config: SableConfig):
+def parse_message(message: DescriptorProto, ctx: ParseContext, parent_message, nested_type_chain: str):
     m = Message()
     m.name = message.name
     m.full_name = f"{ctx.package.name}.{nested_type_chain}{message.name}".lstrip(".")
     m.parent_message = parent_message
-    m.description = config.comments_parser.ParseMessage(ctx.GetComments())
+    m.description = ctx.config.comments_parser.ParseMessage(ctx.GetComments())
     m.description_html = markdown_to_html(m.description, ctx.config)
     m.source_file_path = ctx.source_file_path
     m.line_number = ctx.GetLineNumber()
@@ -191,14 +190,14 @@ def parse_message(message: DescriptorProto, ctx: ParseContext, parent_message, n
 
     # NOTE: The processing of nested types have to happen before processing the fields, to have the Entry nested types representing maps already present.
     new_nested_type_chain = f"{nested_type_chain}{message.name}."
-    parse_messages(message.nested_type, ctx.ExtendPath(COMMENT_MESSAGE_MESSAGE_INDEX), m, new_nested_type_chain, config)
-    parse_enums(message.enum_type, ctx.ExtendPath(COMMENT_MESSAGE_ENUM_INDEX), m, new_nested_type_chain, config)
+    parse_messages(message.nested_type, ctx.ExtendPath(COMMENT_MESSAGE_MESSAGE_INDEX), m, new_nested_type_chain)
+    parse_enums(message.enum_type, ctx.ExtendPath(COMMENT_MESSAGE_ENUM_INDEX), m, new_nested_type_chain)
 
     m.is_map_entry = message.options.map_entry
     for i, mf in enumerate(message.field):
-        m.fields.append(parse_field(mf, message, ctx.ExtendPath(COMMENT_MESSAGE_FIELD_INDEX, i), config))
+        m.fields.append(parse_field(mf, message, ctx.ExtendPath(COMMENT_MESSAGE_FIELD_INDEX, i)))
 
-    if config.member_ordering == MemberOrdering.ALPHABETICAL:
+    if ctx.config.member_ordering == MemberOrdering.ALPHABETICAL:
         m.fields.sort(key=lambda mf: mf.number)
 
     oneof_names = set([f.oneof_name for f in m.fields if f.oneof_name])
@@ -209,18 +208,18 @@ def parse_message(message: DescriptorProto, ctx: ParseContext, parent_message, n
     return m
 
 
-def parse_messages(messages: Sequence[DescriptorProto], ctx: ParseContext, parent_message, nested_type_chain: str, config: SableConfig):
+def parse_messages(messages: Sequence[DescriptorProto], ctx: ParseContext, parent_message, nested_type_chain: str):
     for (i, message) in enumerate(messages):
-        ctx.package.messages.append(parse_message(message, ctx.ExtendPath(i), parent_message, nested_type_chain, config))
+        ctx.package.messages.append(parse_message(message, ctx.ExtendPath(i), parent_message, nested_type_chain))
 
-    if config.member_ordering == MemberOrdering.ALPHABETICAL:
+    if ctx.config.member_ordering == MemberOrdering.ALPHABETICAL:
         ctx.package.messages.sort(key=lambda m: m.name)
 
 
-def parse_service_method(service_method: MethodDescriptorProto, ctx: ParseContext, config: SableConfig):
+def parse_service_method(service_method: MethodDescriptorProto, ctx: ParseContext):
     sm = ServiceMethod()
     sm.name = service_method.name
-    sm.description = config.comments_parser.ParseServiceMethod(ctx.GetComments())
+    sm.description = ctx.config.comments_parser.ParseServiceMethod(ctx.GetComments())
     sm.description_html = markdown_to_html(sm.description, ctx.config)
     sm.line_number = ctx.GetLineNumber()
     sm.request = ServiceMethodArgument(
@@ -238,11 +237,11 @@ def parse_service_method(service_method: MethodDescriptorProto, ctx: ParseContex
     return sm
 
 
-def parse_service(service: ServiceDescriptorProto, ctx: ParseContext, config: SableConfig):
+def parse_service(service: ServiceDescriptorProto, ctx: ParseContext):
     s = Service()
     s.name = service.name
     s.full_name = f"{ctx.package.name}.{service.name}".lstrip(".")
-    s.description = config.comments_parser.ParseService(ctx.GetComments())
+    s.description = ctx.config.comments_parser.ParseService(ctx.GetComments())
     s.description_html = markdown_to_html(s.description, ctx.config)
     s.source_file_path = ctx.source_file_path
     s.line_number = ctx.GetLineNumber()
@@ -254,16 +253,16 @@ def parse_service(service: ServiceDescriptorProto, ctx: ParseContext, config: Sa
         s.source_file_path,
         s.line_number)
     for i, service_method in enumerate(service.method):
-        s.methods.append(parse_service_method(service_method, ctx.ExtendPath(COMMENT_SERVICE_METHOD_INDEX, i), config))
+        s.methods.append(parse_service_method(service_method, ctx.ExtendPath(COMMENT_SERVICE_METHOD_INDEX, i)))
 
     return s
 
 
-def parse_services(services: Sequence[ServiceDescriptorProto], ctx: ParseContext, config: SableConfig):
+def parse_services(services: Sequence[ServiceDescriptorProto], ctx: ParseContext):
     for (i, service) in enumerate(services):
-        ctx.package.services.append(parse_service(service, ctx.ExtendPath(i), config))
+        ctx.package.services.append(parse_service(service, ctx.ExtendPath(i)))
 
-    if config.member_ordering == MemberOrdering.ALPHABETICAL:
+    if ctx.config.member_ordering == MemberOrdering.ALPHABETICAL:
         ctx.package.services.sort(key=lambda s: s.name)
 
 
@@ -383,9 +382,9 @@ def parse_proto_descriptor(sable_config: SableConfig):
             package.description += sable_config.comments_parser.ParsePackage(ctx.GetComments(str(COMMENT_PACKAGE_INDEX)))
             package.description_html = markdown_to_html(package.description, sable_config)
 
-            parse_enums(file.enum_type, ctx.WithPath(COMMENT_ENUM_INDEX), None, "", sable_config)
-            parse_messages(file.message_type, ctx.WithPath(COMMENT_MESSAGE_INDEX), None, "", sable_config)
-            parse_services(file.service, ctx.WithPath(COMMENT_SERVICE_INDEX), sable_config)
+            parse_enums(file.enum_type, ctx.WithPath(COMMENT_ENUM_INDEX), None, "")
+            parse_messages(file.message_type, ctx.WithPath(COMMENT_MESSAGE_INDEX), None, "")
+            parse_services(file.service, ctx.WithPath(COMMENT_SERVICE_INDEX))
 
             all_messages.extend(package.messages)
             all_enums.extend(package.enums)

--- a/src/sabledocs/sable_config.py
+++ b/src/sabledocs/sable_config.py
@@ -33,6 +33,7 @@ class SableConfig:
         self.repository_type = RepositoryType.NONE
         self.ignore_comments_after: List[str] = []
         self.ignore_comment_lines_containing: List[str] = []
+        self.comments_parser_file = None
         self.hidden_packages: List[str] = []
         self.member_ordering = MemberOrdering.ALPHABETICAL
         self.markdown_extensions: List[str] = ['fenced_code']
@@ -67,6 +68,7 @@ class SableConfig:
 
                 self.ignore_comments_after = config_values.get('ignore-comments-after', [])
                 self.ignore_comment_lines_containing = config_values.get('ignore-comment-lines-containing', [])
+                self.comments_parser_file = config_values.get('comments-parser-file', None)
                 self.hidden_packages = config_values.get('hidden-packages', [])
                 self.markdown_extensions = config_values.get('markdown-extensions', self.markdown_extensions)
 


### PR DESCRIPTION
In an effort to provide more information about fields (beside the name, type, and how they are serialized) than is within the scope of .proto files, I have been using this hack for embedding additional information.
Actually, this PR is just the hooks for doing additional processing on the comments, not the processing itself.

The idea is to allow the user to indicate an arbitrary python source file that defines a new class for parsing comments preceeding fields, packages, messages, enums, enum values, packages, services, and service methods (even though I have only used it to date with fields).

In my case, I format the docstring as JSON object, and one of the keys (`"desc"`) still provides the string that will be insert into the HTML, but I can add other qualifiers like this:
```json
{"desc": "A really good field",
 "valid_range": [0,360],
 "searchable": true}
```
which are pertinent to other code which consumes those values.
I also append to the `"desc"` string things like "\n\nThis field is searchable, and its valid range is [0,360]."

Separately, I mimicked the protobuf parsing facilities in sabledocs in a different python script that extracts these same strings, but then generates code based on the other qualifiers (but that's just anecdotal).

And -- thank you for this excellent package!