### PR TITLE
Return 1 exit code on errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sabledocs"
-version = "0.16"
+version = "0.17"
 authors = [
   { name="Mark Vincze", email="mrk.vincze@gmail.com" },
 ]


### PR DESCRIPTION
Previously when we had errors, the CLI was still returning an exit code `0`, which is a problem for CI builds, as that execution is not detected as a failure.

Fixes #85 